### PR TITLE
Fix for empty forwarded_from attribute

### DIFF
--- a/src/routes/bot/utils.js
+++ b/src/routes/bot/utils.js
@@ -22,12 +22,13 @@ function getMailBtn () {
 }
 
 function getUserName(user) {
+    if (!user) return '';
     if (user.username) {
-        return "@" + user.username
+        return "@" + user.username;
     }
-    let fullname = user.first_name
+    let fullname = user.first_name;
     if (user.last_name) fullname = fullname + " " + user.last_name
-    return fullname
+    return fullname;
 }
 
 async function notifyUsers(foundRequest, fakeStatus, bot) {


### PR DESCRIPTION
In some cases (IDK why) when message is forwarded it does not include 'forward_from' attribute. For this cases added additional check in getUserName function.