### PR TITLE
Trim query params from links

### DIFF
--- a/src/routes/bot/message-handlers.js
+++ b/src/routes/bot/message-handlers.js
@@ -35,6 +35,7 @@ const {
     updateSource,
     getUserName,
     checkUserThrottling,
+    removeQueryParamsFromLink,
 } = require("./utils");
 
 const {
@@ -391,7 +392,8 @@ const onCheckRequest = async (msg, bot) => {
 
     if (msg.text) { //Get text data
         const labeledSource = await getLabeledSource(msg.text);
-        const foundText = await Request.findOne({text: msg.text}, '_id fakeStatus commentChatId commentMsgId');
+        const requestText = removeQueryParamsFromLink(msg.text);
+        const foundText = await Request.findOne({text: requestText}, '_id fakeStatus commentChatId commentMsgId');
         if (foundText) {
             if (foundText.fakeStatus === 0) return addToWaitlist(msg, foundText, bot);
             return reportStatus(msg, foundText, bot, labeledSource);
@@ -412,7 +414,7 @@ const onCheckRequest = async (msg, bot) => {
             } catch (e) {safeErrorLog(e)}
         } 
 
-        request.text = msg.text;
+        request.text = requestText;
     } else if (msg.caption) {
         request.text = msg.caption;
     }

--- a/src/routes/bot/utils.js
+++ b/src/routes/bot/utils.js
@@ -1,4 +1,5 @@
 const mongoose = require("mongoose");
+const { URL } = require('url');
 const { getText, getLanguageTGChat} = require('./localisation');
 const {RequestThrottleLimit} = require("./contstants");
 const Request = mongoose.model('Request');
@@ -426,6 +427,16 @@ function updateTextsList(oldList, newList) {
   return result;
 }
 
+function removeQueryParamsFromLink(link) {
+  try {
+    const url = new URL(link);
+    url.search = '';
+    return url.href;
+  } catch (error) {
+    // If the input is not a valid URL, return the input as it is.
+    return link;
+  }
+}
 
 module.exports = {
     getSubscriptionBtn,
@@ -449,6 +460,7 @@ module.exports = {
     getFakeText,
     checkUserThrottling,
     updateTextsList,
+    removeQueryParamsFromLink,
 }
 
 async function notifyViber(text, viberRequester) {


### PR DESCRIPTION
In order to make better results for matching links that were already processed we need to remove query params from urls as they usually contain just technical and marketing data.